### PR TITLE
Don't mute/unmute on other timelines

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Promute",
   "manifest_version": 2,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Promute automatically mutes twitter accounts sending promotions to your timeline as you scroll by.",
   "icons": {
     "16": "./logo_16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "promute",
+  "version": "1.0.5",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "promute",
+      "version": "1.0.5",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promute",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Promute is a Chrome Extension that automatically mutes twitter accounts sending promotions to your timeline as you scroll by.",
   "scripts": {
     "dist": "zip dist.zip manifest.json promute.js LICENSE README.md logo_*.png" 

--- a/promute.js
+++ b/promute.js
@@ -1,4 +1,4 @@
-const XPATH_PROMOTED_TWEET_MENU_ACTIVATORS = '//div[@role="group"]/../following-sibling::div/../../..//div[@aria-label="More"]'
+const XPATH_PROMOTED_TWEET_MENU_ACTIVATORS = '//div[@role="group"]/../following-sibling::div[node()]/../../..//div[@aria-label="More"]'
 const XPATH_MUTE_BUTTON = '//div[@role="menu"]//div[@data-testid="block"]/preceding-sibling::div[@role="menuitem"][1]'
 
 function debounce(func, wait = 100) {


### PR DESCRIPTION
Closes #1

- Increment version
- Don't mute/unmute everything on other account's timelines Ignore empty div after action group div, which occurs for timelines. That makes the 'promoted tweet if action group div is followed by another div as sibling' work again w/o ill side effects (... that I know of)
